### PR TITLE
Fix Unicode report timestamp and add report links

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,7 +166,8 @@ def report(project):
     # Create document
     doc = Document()
     doc.add_heading(f"รายงานประกอบการซ่อมแซมโครงสร้าง — โปรเจ็กต์ {project}", level=0)
-    doc.add_paragraph(datetime.now().strftime("วันที่จัดทำรายงาน: %d/%m/%Y %H:%M"))
+    # Separate Thai text from strftime to avoid UnicodeEncodeError
+    doc.add_paragraph("วันที่จัดทำรายงาน: " + datetime.now().strftime("%d/%m/%Y %H:%M"))
 
     # For each point
     for point in sorted(data.keys(), key=lambda x: str(x)):

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -3,12 +3,13 @@
 <div class="p-4 bg-white rounded-xl shadow">
   <h2 class="font-semibold mb-3">โปรเจ็กต์ทั้งหมด</h2>
   <ul class="list-disc pl-5">
-    {% for r in projects %}
-      <li class="mb-1">
-        <a class="text-blue-600 hover:underline" href="{{ url_for('browse', project=r['name']) }}">{{ r['name'] }}</a>
-        <span class="text-xs text-gray-500">— {{ r['created_at'] }}</span>
-      </li>
-    {% endfor %}
+      {% for r in projects %}
+        <li class="mb-1">
+          <a class="text-blue-600 hover:underline" href="{{ url_for('browse', project=r['name']) }}">{{ r['name'] }}</a>
+          <a class="ml-2 text-green-600 hover:underline" href="{{ url_for('report', project=r['name']) }}">ดาวน์โหลดรายงาน</a>
+          <span class="text-xs text-gray-500">— {{ r['created_at'] }}</span>
+        </li>
+      {% endfor %}
   </ul>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Avoid UnicodeEncodeError when adding Thai timestamp to reports
- Provide direct .docx download links for projects

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from docx import Document
from datetime import datetime
import os, tempfile

doc=Document()
doc.add_paragraph("วันที่จัดทำรายงาน: " + datetime.now().strftime("%d/%m/%Y %H:%M"))
fd, path = tempfile.mkstemp(suffix='.docx'); os.close(fd)
doc.save(path)
print('generated', os.path.basename(path))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68961845778c8320bdad5e817156157d